### PR TITLE
Added support for Revision 2 boards

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,6 @@
+version 0.0.7
+- new pin mapping for Revision 2 boards, see https://projects.drogon.net/raspberry-pi/wiringpi/pins/ and http://www.raspberrypi-spy.co.uk/2012/06/simple-guide-to-the-rpi-gpio-header-and-pins/
+
 version 0.0.6
 - new reading method File.new and f.getc/rewind that gets into ~35 microsecond reads instead of ~55 microsecond IO.new io.getc/rewind and ~350 microsecond reads with IO.read
 - typed input/output pins, mainly to prepare for pwm, bidirectional/1wire, and more

--- a/gpio.gemspec
+++ b/gpio.gemspec
@@ -1,11 +1,11 @@
 Gem::Specification.new do |s|
   s.name        = 'gpio'
-  s.version     = '0.0.6'
-  s.date        = '2012-06-08'
+  s.version     = '0.0.7'
+  s.date        = '2012-09-29'
   s.homepage    = 'http://klappy.github.com/gpio'
   s.summary     = "a ruby gem and repository to contribute gpio code for devices such as Raspberry Pi to read sensors and control outputs."
   s.description = "gpio allows for devices such as raspberry pi or systems with 1wire usb adapters to speak to the system's input/output pins."
-  s.authors     = ['Christopher Klapp']
+  s.authors     = ['Christopher Klapp', 'Sven Kraeuter']
   s.email       = 'christopher@klapp.name'
   s.files       = Dir.glob("{lib}/**/*") + %w(README.md changelog)
 end

--- a/lib/gpio.rb
+++ b/lib/gpio.rb
@@ -1,1 +1,1 @@
-%w[device devices/raspberry_pi pin pins/input_pin pins/output_pin sensor sensors/motion_detector sensors/ping_sonar outputs/led outputs/traffic_light].each{|file| require File.dirname(__FILE__)+'/gpio/'+file}
+%w[device devices/raspberry_pi devices/raspberry_pi_revision_2 pin pins/input_pin pins/output_pin sensor sensors/motion_detector sensors/ping_sonar outputs/led outputs/traffic_light].each{|file| require File.dirname(__FILE__)+'/gpio/'+file}

--- a/lib/gpio/devices/raspberry_pi_revision_2.rb
+++ b/lib/gpio/devices/raspberry_pi_revision_2.rb
@@ -1,0 +1,18 @@
+module GPIO
+  module RaspberryPiRevision2
+    extend Device
+
+    VALIDATE_FILE = "/sys/class/gpio/gpiochip0/label"
+    VALIDATE_VALUE = "bcm2708_gpio"
+
+    MAPPING = :hardware
+    HARDWARE_PINS = [3,5,7,8,10,11,12,13,15,16,17,19,21,22,23,24,26]
+    SOFTWARE_PINS = [2,3,4,14,15,17,18,27,22,23,24,10,9,25,11,8,7]
+    BASE_PATH = '/sys/class/gpio/'
+    EXPORT_PATH = "#{BASE_PATH}export"
+    UNEXPORT_PATH = "#{BASE_PATH}unexport"
+    PIN_PREFIX = "gpio"
+    DIRECTION_FILE = "direction"
+    VALUE_FILE = "value"
+  end
+end


### PR DESCRIPTION
Used the gpio mapping described by [drogon](https://projects.drogon.net/raspberry-pi/wiringpi/pins/) and [raspberry spy](http://www.raspberrypi-spy.co.uk/2012/06/simple-guide-to-the-rpi-gpio-header-and-pins/) - fixes issue #1 on my Revision 2 board.
