### PR TITLE
Adding support for beaglebone black

### DIFF
--- a/lib/gpio.rb
+++ b/lib/gpio.rb
@@ -1,1 +1,1 @@
-%w[device devices/raspberry_pi devices/raspberry_pi_revision_2 pin pins/input_pin pins/output_pin sensor sensors/motion_detector sensors/ping_sonar outputs/led outputs/traffic_light].each{|file| require File.dirname(__FILE__)+'/gpio/'+file}
+%w[device devices/raspberry_pi devices/raspberry_pi_revision_2 devices/beaglebone_black pin pins/input_pin pins/output_pin sensor sensors/motion_detector sensors/ping_sonar outputs/led outputs/traffic_light].each{|file| require File.dirname(__FILE__)+'/gpio/'+file}

--- a/lib/gpio/devices/beaglebone_black.rb
+++ b/lib/gpio/devices/beaglebone_black.rb
@@ -1,0 +1,18 @@
+module GPIO
+	module BeagleboneBlack
+		extend Device
+
+		VALIDATE_FILE = "/sys/class/gpio/gpiochip96/label"
+		VALIDATE_VALUE = "chipset_gpio"
+
+		MAPPING = :hardware
+		HARDWARE_PINS = [2,3,4,5,7,14,15,20,26,27,30,31,40,44,45,46,47,48,49,51,60,61,65,66,67,68,69,117,120,121,122,123,125]
+		SOFTWARE_PINS = [2,3,4,5,7,14,15,20,26,27,30,31,40,44,45,46,47,48,49,51,60,61,65,66,67,68,69,117,120,121,122,123,125]
+		BASE_PATH = '/sys/class/gpio/'
+		EXPORT_PATH = "#{BASE_PATH}export"
+		UNEXPORT_PATH = "#{BASE_PATH}unexport"
+		PIN_PREFIX = "gpio"
+		DIRECTION_FILE = "direction"
+		VALUE_FILE = "value"
+	end
+end


### PR DESCRIPTION
Hellio, 

I have been using your gpio gem with a Beaglebone Black and I had to  add some support for it. 
A few notes : 
Not sure why the  :hardware and ;software pins should be different for the beaglebone. There is only one number that makes sense to me...

All the pins I have added  have been tested on a latest revision BBB (rev C) and  the older rev A5.

``` ruby
 [2,3,4,5,7,14,15,20,26,27,30,31,40,44,45,46,47,48,49,51,60,61,65,66,67,68,69,117,120,121,122,123,125].each() { |x| p GPIO::OutputPin.new(device: :BeagleboneBlack, pin: x, mode: :out)}
```

The BBB has 4 gpio controllers  - gpiochip0, gpiochip32, gpiochip64 and gpiochip96 - I use the last one for the VALIDATE_FILE, 

 Antonios
